### PR TITLE
fix(mainWindow be freed when quitting)

### DIFF
--- a/electron/win.js
+++ b/electron/win.js
@@ -64,21 +64,13 @@ export function setWindowPostionFromDB() {
 }
 
 export function saveCurrentWindowPosition() {
-  db.findOne({ window: 'position' }, (err, doc) => {
-    if (doc !== null) {
-      db.update(
-        { window: 'position' },
-        {
-          $set: {
-            pos: getCurrentWindowPostion()
-          }
-        }
-      )
-    } else {
-      db.insert({
-        window: 'position',
-        pos: getCurrentWindowPostion()
-      })
-    }
+  db.update({
+    window: 'position'
+  }, {
+    window: 'position',
+    pos: getCurrentWindowPostion()
+  }, {
+    multi: false,
+    upsert: true
   })
 }


### PR DESCRIPTION
虽然本质是个use-after-free的数据竞争问题，但我没太弄明白有多个BrowserWindow的时候，electron quit的清理顺序，所以理论上这个问题没有完全解决。